### PR TITLE
make serializer configurable via django settings

### DIFF
--- a/djangocms_transfer/__init__.py
+++ b/djangocms_transfer/__init__.py
@@ -1,3 +1,7 @@
 __version__ = '1.0.0'
 
 default_app_config = 'djangocms_transfer.apps.TranferConfig'
+
+def get_serializer_name(default='python'):
+    from django.conf import settings
+    return getattr(settings, 'DJANGO_CMS_TRANSFER_SERIALIZER', default)

--- a/djangocms_transfer/__init__.py
+++ b/djangocms_transfer/__init__.py
@@ -2,6 +2,7 @@ __version__ = '1.0.0'
 
 default_app_config = 'djangocms_transfer.apps.TranferConfig'
 
+
 def get_serializer_name(default='python'):
     from django.conf import settings
     return getattr(settings, 'DJANGO_CMS_TRANSFER_SERIALIZER', default)

--- a/djangocms_transfer/datastructures.py
+++ b/djangocms_transfer/datastructures.py
@@ -7,6 +7,7 @@ from django.utils.functional import cached_property
 
 from cms.models import CMSPlugin
 
+from . import get_serializer_name
 from .utils import get_plugin_model
 
 
@@ -35,7 +36,7 @@ class ArchivedPlugin(BaseArchivedPlugin):
         }
 
         # TODO: Handle deserialization error
-        return list(deserialize('python', [data]))[0]
+        return list(deserialize(get_serializer_name(), [data]))[0]
 
     @transaction.atomic
     def restore(self, placeholder, language, parent=None, with_data=True):

--- a/djangocms_transfer/helpers.py
+++ b/djangocms_transfer/helpers.py
@@ -2,6 +2,7 @@ from collections import defaultdict
 
 from django.core import serializers
 
+from . import get_serializer_name
 from .utils import get_plugin_fields, get_plugin_model
 
 
@@ -41,7 +42,7 @@ def get_plugin_data(plugin, only_meta=False):
         custom_data = None
     else:
         plugin_fields = get_plugin_fields(plugin.plugin_type)
-        _plugin_data = serializers.serialize('python', (plugin,), fields=plugin_fields)[0]
+        _plugin_data = serializers.serialize(get_serializer_name(), (plugin,), fields=plugin_fields)[0]
         custom_data = _plugin_data['fields']
 
     plugin_data = {


### PR DESCRIPTION
Being able to change the serializer via Django Settings it is possible to implement advanced export/import schemes without touching djangocms-transfer itself.

Example: We subclassed Django's build-in python serializer and made it inline image data base64 encoded. Once the serializer is registered in Django (possible via Settings), we can use it in djangocms-transfer and are now able to export and import between different installations including images.

Other use-cases might be possible as well with custom serializers ...

