### PR TITLE
Fix error on export when getting filename

### DIFF
--- a/djangocms_transfer/forms.py
+++ b/djangocms_transfer/forms.py
@@ -103,17 +103,18 @@ class PluginExportForm(ExportImportForm):
             return "{}.json".format(
                 page.get_slug(language=language)
             )
-
-        if placeholder:
+        elif placeholder and placeholder.page is not None:
             return "{}_{}.json".format(
                 placeholder.page.get_slug(language=language),
                 slugify(placeholder.slot)
             )
-
-        return "{}_{}.json".format(
-            plugin.page.get_slug(language=language),
-            slugify(plugin.get_short_description())
-        )
+        elif plugin is not None and plugin.page is not None:
+            return "{}_{}.json".format(
+                plugin.page.get_slug(language=language),
+                slugify(plugin.get_short_description())
+            )
+        else:
+            return 'plugins.json'
 
     def run_export(self):
         data = self.cleaned_data


### PR DESCRIPTION
- error occurs on static-placeholder (placeholder.page == None)
- other example: error occurs on "post"-content-export for djangocms-blog

Both cases result in an AttributeError for trying 'None.get_slug()'.

----

This error was introduced with the changes in #15.

With the changes of this PR the occuring `AttributeError` is avoided and a fallback filename used if no "page" is present.