### PR TITLE
feat: update CI/CD and lint

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,38 +1,25 @@
 name: Lint
 
-on: [push]
+on: [push, pull_request]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  flake8:
-    name: flake8
+  ruff:
+    name: ruff
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.9
-      - name: Install flake8
-        run: pip install --upgrade flake8
-      - name: Run flake8
-        uses: liskin/gh-problem-matcher-wrap@v1
-        with:
-          linters: flake8
-          run: flake8
-
-  isort:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.9
-      - run: python -m pip install isort
-      - name: isort
-        uses: liskin/gh-problem-matcher-wrap@v1
-        with:
-          linters: isort
-          run: isort --check-only --df djangocms_transfer
+          python-version: "3.12"
+          cache: "pip"
+      - run: |
+          python -m pip install --upgrade pip
+          pip install ruff
+      - name: Run Ruff
+        run: ruff check djangocms_transfer tests

--- a/.github/workflows/publish-to-live-pypi.yml
+++ b/.github/workflows/publish-to-live-pypi.yml
@@ -10,11 +10,11 @@ jobs:
     name: Build and publish Python 🐍 distributions 📦 to pypi
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v4
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.12
+      uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
+        python-version: '3.12'
 
     - name: Install pypa/build
       run: >-

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -10,11 +10,11 @@ jobs:
     name: Build and publish Python 🐍 distributions 📦 to TestPyPI
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v4
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.12
+      uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
+        python-version: '3.12'
 
     - name: Install pypa/build
       run: >-

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,9 +23,9 @@ jobs:
           - requirements-file: dj51_cms41.txt
             python-version: 3.9
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -38,4 +38,6 @@ jobs:
       run: coverage run tests/settings.py
 
     - name: Upload Coverage to Codecov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/djangocms_transfer/cms_plugins.py
+++ b/djangocms_transfer/cms_plugins.py
@@ -1,16 +1,15 @@
 import json
 
+from cms.plugin_base import CMSPluginBase, PluginMenuItem
+from cms.plugin_pool import plugin_pool
+from cms.utils import get_language_from_request
+from cms.utils.urlutils import admin_reverse
 from django.core.exceptions import PermissionDenied
 from django.http import HttpResponse, HttpResponseBadRequest
 from django.shortcuts import render
 from django.urls import re_path, reverse
 from django.utils.http import urlencode
 from django.utils.translation import gettext_lazy as _
-
-from cms.plugin_base import CMSPluginBase, PluginMenuItem
-from cms.plugin_pool import plugin_pool
-from cms.utils import get_language_from_request
-from cms.utils.urlutils import admin_reverse
 
 from .forms import ExportImportForm, PluginExportForm, PluginImportForm
 

--- a/djangocms_transfer/cms_toolbars.py
+++ b/djangocms_transfer/cms_toolbars.py
@@ -1,11 +1,10 @@
-from django.utils.http import urlencode
-from django.utils.translation import gettext
-
 from cms.models import PageContent
 from cms.toolbar_base import CMSToolbar
 from cms.toolbar_pool import toolbar_pool
 from cms.utils.page_permissions import user_can_change_page
 from cms.utils.urlutils import admin_reverse
+from django.utils.http import urlencode
+from django.utils.translation import gettext
 
 
 @toolbar_pool.register

--- a/djangocms_transfer/compat.py
+++ b/djangocms_transfer/compat.py
@@ -1,6 +1,4 @@
 import cms
-
 from packaging.version import Version
-
 
 cms_version = Version(cms.__version__)

--- a/djangocms_transfer/datastructures.py
+++ b/djangocms_transfer/datastructures.py
@@ -1,16 +1,14 @@
 from collections import namedtuple
 
+from cms.api import add_plugin
+from cms.models import CMSPlugin
 from django.core.serializers import deserialize
 from django.db import transaction
 from django.utils.encoding import force_str
 from django.utils.functional import cached_property
 
-from cms.api import add_plugin
-from cms.models import CMSPlugin
-
 from . import get_serializer_name
 from .utils import get_plugin_model
-
 
 BaseArchivedPlugin = namedtuple(
     "ArchivedPlugin",

--- a/djangocms_transfer/exporter.py
+++ b/djangocms_transfer/exporter.py
@@ -5,7 +5,6 @@ from django.core.serializers.json import DjangoJSONEncoder
 
 from . import helpers
 
-
 dump_json = functools.partial(json.dumps, cls=DjangoJSONEncoder)
 
 

--- a/djangocms_transfer/forms.py
+++ b/djangocms_transfer/forms.py
@@ -1,12 +1,11 @@
 import json
 
+from cms.models import CMSPlugin, PageContent, Placeholder
 from django import forms
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.utils.text import slugify
 from django.utils.translation import gettext_lazy as _
-
-from cms.models import CMSPlugin, PageContent, Placeholder
 
 from .datastructures import ArchivedPlaceholder, ArchivedPlugin
 from .exporter import export_page, export_placeholder, export_plugin

--- a/djangocms_transfer/importer.py
+++ b/djangocms_transfer/importer.py
@@ -1,6 +1,5 @@
-from django.db import transaction
-
 from cms.models import CMSPlugin
+from django.db import transaction
 
 from .utils import get_plugin_class
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,27 +51,23 @@ packages = [ "djangocms_transfer" ]
 [tool.setuptools.dynamic]
 version = { attr = "djangocms_transfer.__version__" }
 
-[tool.flake8]
-max-line-length = 119
-exclude = [
-    "*.egg-info",
-    ".eggs",
-    ".git",
-    ".settings",
-    ".tox",
+[tool.ruff]
+lint.exclude = [
+    ".env",
     ".venv",
-    "build",
-    "data",
-    "dist",
-    "docs",
-    "*migrations*",
-    "requirements",
-    "tmp"
+    "**/migrations/**",
+]
+lint.ignore = [
+    "E501",  # line too long
+    "F403",  # 'from module import *' used; unable to detect undefined names
+    "E701",  # multiple statements on one line (colon)
+    "F401",  # module imported but unused
+]
+line-length = 119
+lint.select = [
+    "I",
+    "E",
+    "F",
+    "W",
 ]
 
-[tools.isort]
-line_length = 119
-skip = ["manage.py", "*migrations*", ".tox", ".eggs", "data"]
-include_trailing_comma = true
-multi_line_output = 5
-lines_after_imports = 2

--- a/tests/transfer/abstract.py
+++ b/tests/transfer/abstract.py
@@ -1,7 +1,6 @@
+from cms.api import add_plugin, create_page
 from cms.test_utils.testcases import CMSTestCase
 from freezegun import freeze_time
-
-from cms.api import add_plugin, create_page
 
 
 @freeze_time("2024-02-28 00:00:00")

--- a/tests/transfer/test_forms.py
+++ b/tests/transfer/test_forms.py
@@ -7,7 +7,6 @@ from django.core.files import File
 
 from djangocms_transfer.forms import PluginExportForm, PluginImportForm
 
-
 from .abstract import FunctionalityBaseTestCase
 
 

--- a/tests/transfer/test_import.py
+++ b/tests/transfer/test_import.py
@@ -1,8 +1,8 @@
 import json
 
 from djangocms_transfer.datastructures import (
-    ArchivedPlugin,
     ArchivedPlaceholder,
+    ArchivedPlugin,
 )
 from djangocms_transfer.exporter import export_placeholder, export_plugin
 from djangocms_transfer.importer import import_plugins, import_plugins_to_page


### PR DESCRIPTION
The actions were outdated, and the lint was using isort and flak8 still.

All actions are updated to the latest and greatest and at the same time ruff is introduced in this codebase as well.

Ruff lint found some issues which are automatically fixed using ruff.

## Description

<!--
If this is a security issue stop right here and follow our documentation:
http://docs.django-cms.org/en/latest/contributing/development-policies.html#reporting-security-issues
-->

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``master``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

CI:
- Update GitHub Actions workflows to use the latest versions of actions/checkout and actions/setup-python, and switch from flake8 and isort to ruff for linting.