### PR TITLE
chore: Update docs, fix clashing arguments on LinkPlugin

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,25 +18,6 @@ key relations and won't import/export related data, such as `media <https://gith
 .. image:: preview.gif
 
 
-*******************************************
-Contribute to this project and win rewards
-*******************************************
-
-Because this is an open-source project, we welcome everyone to
-`get involved in the project <https://www.django-cms.org/en/contribute/>`_ and
-`receive a reward <https://www.django-cms.org/en/bounty-program/>`_ for their contribution.
-Become part of a fantastic community and help us make django CMS the best CMS in the world.
-
-We'll be delighted to receive your
-feedback in the form of issues and pull requests. Before submitting your
-pull request, please review our `contribution guidelines
-<http://docs.django-cms.org/en/latest/contributing/index.html>`_.
-
-We're grateful to all contributors who have helped create and maintain this package.
-Contributors are listed at the `contributors <https://github.com/django-cms/djangocms-transfer/graphs/contributors>`_
-section.
-
-
 Documentation
 =============
 
@@ -54,7 +35,6 @@ For a manual install:
 
 * run ``pip install djangocms-transfer``
 * add ``djangocms_transfer`` to your ``INSTALLED_APPS``
-* run ``python manage.py migrate djangocms_transfer``
 
 
 Version Compatibility
@@ -63,6 +43,16 @@ Version Compatibility
 For django CMS 4.0 or later, you must use djangocms-transfer 2.0 or later.
 
 For django CMS 3.7 through 3.11 use versions 1.x of djangocms-transfer.
+
+
+How to Use
+----------
+
+To export/import a page, click on the "*Page*" menu on the toolbar
+and select your desired choice.
+
+To export/import a plugin, Open the "*Structure board*", click on the
+dropdown menu for the specific plugin and select your choice.
 
 
 Customization
@@ -116,15 +106,29 @@ Running Tests
 
 You can run tests by executing::
 
-    virtualenv env
+    python -m venv env
     source env/bin/activate
-    pip install -r tests/requirements/base.txt
-    python setup.py test
+    pip install -r tests/requirements/dj51_cms41.txt
+    coverage run tests/settings.py
 
-For code formatting, `black` is used. To automatically fix errors reported from
-`black`, you can install it via virtualenv and
-`pip install -r tests/requirements/base.txt`.
-After this you just need to run `tools/black`.
+
+*******************************************
+Contribute to this project and win rewards
+*******************************************
+
+Because this is an open-source project, we welcome everyone to
+`get involved in the project <https://www.django-cms.org/en/contribute/>`_ and
+`receive a reward <https://www.django-cms.org/en/bounty-program/>`_ for their contribution.
+Become part of a fantastic community and help us make django CMS the best CMS in the world.
+
+We'll be delighted to receive your
+feedback in the form of issues and pull requests. Before submitting your
+pull request, please review our `contribution guidelines
+<http://docs.django-cms.org/en/latest/contributing/index.html>`_.
+
+We're grateful to all contributors who have helped create and maintain this package.
+Contributors are listed at the `contributors <https://github.com/django-cms/djangocms-transfer/graphs/contributors>`_
+section.
 
 
 .. |pypi| image:: https://badge.fury.io/py/djangocms-transfer.svg

--- a/djangocms_transfer/datastructures.py
+++ b/djangocms_transfer/datastructures.py
@@ -53,6 +53,10 @@ class ArchivedPlugin(BaseArchivedPlugin):
                             obj = None
                         data[field.name] = obj
 
+        # The "data" field for LinkPlugin have key, "target"
+        # which clashes with :func:add_plugin when unpacked.
+        plugin_target = data.pop("target", "")
+
         plugin = add_plugin(
             placeholder,
             self.plugin_type,
@@ -61,6 +65,11 @@ class ArchivedPlugin(BaseArchivedPlugin):
             target=parent,
             **data,
         )
+
+        field = ("target",) if plugin_target else ()
+        # An empty *update_fields* iterable will skip the save
+        plugin.target = plugin_target
+        plugin.save(update_fields=field)
 
         if self.model is not CMSPlugin:
             fields = self.model._meta.get_fields()

--- a/djangocms_transfer/forms.py
+++ b/djangocms_transfer/forms.py
@@ -173,7 +173,7 @@ class PluginImportForm(ExportImportForm):
         if target_page:
             import_plugins_to_page(
                 placeholders=data["import_data"],
-                page=target_page,
+                pagecontent=target_page,
                 language=language,
             )
         else:

--- a/djangocms_transfer/importer.py
+++ b/djangocms_transfer/importer.py
@@ -49,8 +49,8 @@ def import_plugins(plugins, placeholder, language, root_plugin_id=None):
 
 
 @transaction.atomic
-def import_plugins_to_page(placeholders, page, language):
-    page_placeholders = page.rescan_placeholders(language)
+def import_plugins_to_page(placeholders, pagecontent, language):
+    page_placeholders = pagecontent.rescan_placeholders()
 
     for archived_placeholder in placeholders:
         plugins = archived_placeholder.plugins

--- a/tests/transfer/test_import.py
+++ b/tests/transfer/test_import.py
@@ -12,8 +12,8 @@ from .abstract import FunctionalityBaseTestCase
 
 class ImportTest(FunctionalityBaseTestCase):
     def test_import(self):
-        page = self.page
-        placeholder = self.page_content.get_placeholders().get(slot="content")
+        pagecontent = self.page_content
+        placeholder = pagecontent.get_placeholders().get(slot="content")
         plugin = self._create_plugin()
 
         plugin_data = ArchivedPlugin(**json.loads(export_plugin(plugin))[0])
@@ -29,4 +29,4 @@ class ImportTest(FunctionalityBaseTestCase):
             import_plugins(placeholder_data.plugins, placeholder, "en")
 
         with self.subTest("import page"):
-            import_plugins_to_page([placeholder_data], page, "en")
+            import_plugins_to_page([placeholder_data], pagecontent, "en")


### PR DESCRIPTION
## Description

- Update README.rst
- Consistent argument name on import_plugin_to_page
- Fix error with Link.target clashing with add_plugins

<!--
If this is a security issue stop right here and follow our documentation:
http://docs.django-cms.org/en/latest/contributing/development-policies.html#reporting-security-issues
-->

## Related resources


## Checklist

* [x] I have opened this pull request against ``master``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Extract LinkPlugin target before plugin creation to avoid argument collision, rename import_plugins_to_page parameter to pagecontent across code and tests, and update the README documentation

Bug Fixes:
- Fix LinkPlugin "target" field clashing with add_plugin unpacking

Enhancements:
- Standardize import_plugins_to_page signature and calls to use "pagecontent" instead of "page"

Documentation:
- Update README.rst

Tests:
- Adjust import tests to use the renamed "pagecontent" parameter