### PR TITLE
feat: django-cms 5.0 compatibility & restored import callback invocation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,9 +10,14 @@ jobs:
       matrix:
         python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13"]
         requirements-file: [
+          dj42_cms41.txt,
           dj50_cms41.txt,
           dj51_cms41.txt,
-          dj42_cms41.txt,
+          dj52_cms41.txt,
+          dj42_cms50.txt,
+          dj50_cms50.txt,
+          dj51_cms50.txt,
+          dj52_cms50.txt,
         ]
         os: [
           ubuntu-latest,
@@ -21,6 +26,14 @@ jobs:
           - requirements-file: dj50_cms41.txt
             python-version: 3.9
           - requirements-file: dj51_cms41.txt
+            python-version: 3.9
+          - requirements-file: dj52_cms41.txt
+            python-version: 3.9
+          - requirements-file: dj50_cms50.txt
+            python-version: 3.9
+          - requirements-file: dj51_cms50.txt
+            python-version: 3.9
+          - requirements-file: dj52_cms50.txt
             python-version: 3.9
     steps:
     - uses: actions/checkout@v4

--- a/djangocms_transfer/cms_plugins.py
+++ b/djangocms_transfer/cms_plugins.py
@@ -160,11 +160,11 @@ class PluginImporter(CMSPluginBase):
                 request, obj=new_plugins[0]
             )
 
-        from cms.toolbar.utils import get_plugin_tree_as_json
+        from cms.toolbar.utils import get_plugin_tree
 
         # Placeholder plugins import
         new_plugins = placeholder.get_plugins(language).exclude(pk__in=tree_order)
-        data = json.loads(get_plugin_tree_as_json(request, list(new_plugins)))
+        data = get_plugin_tree(request, list(new_plugins))
         data["plugin_order"] = tree_order + ["__COPY__"]
         data["target_placeholder_id"] = placeholder.pk
         context = {"structure_data": json.dumps(data)}

--- a/djangocms_transfer/forms.py
+++ b/djangocms_transfer/forms.py
@@ -133,7 +133,10 @@ class PluginExportForm(ExportImportForm):
 
 
 class PluginImportForm(ExportImportForm):
-    import_file = forms.FileField(required=True)
+    import_file = forms.FileField(
+        required=True,
+        widget=forms.FileInput(attrs={"accept": "application/json"}),
+    )
 
     def clean(self):
         if self.errors:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ classifiers = [
     "Framework :: Django :: 5.1",
     "Framework :: Django CMS",
     "Framework :: Django CMS :: 4.1",
+    "Framework :: Django CMS :: 5.0",
     "Topic :: Internet :: WWW/HTTP",
     "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
     "Topic :: Software Development",

--- a/tests/requirements/dj42_cms50.txt
+++ b/tests/requirements/dj42_cms50.txt
@@ -1,0 +1,4 @@
+-r base.txt
+
+Django>=4.2,<5.0
+django-cms>=5.0,<5.1

--- a/tests/requirements/dj50_cms50.txt
+++ b/tests/requirements/dj50_cms50.txt
@@ -1,0 +1,4 @@
+-r base.txt
+
+Django>=5.0,<5.1
+django-cms>=5.0,<5.1

--- a/tests/requirements/dj51_cms50.txt
+++ b/tests/requirements/dj51_cms50.txt
@@ -1,0 +1,4 @@
+-r base.txt
+
+Django>=5.1,<5.2
+django-cms>=5.0,<5.1

--- a/tests/requirements/dj52_cms41.txt
+++ b/tests/requirements/dj52_cms41.txt
@@ -1,0 +1,4 @@
+-r base.txt
+
+Django>=5.2,<5.3
+django-cms>=4.1,<4.2

--- a/tests/requirements/dj52_cms50.txt
+++ b/tests/requirements/dj52_cms50.txt
@@ -1,0 +1,4 @@
+-r base.txt
+
+Django>=5.2,<5.3
+django-cms>=5.0,<5.1

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     py{39}-dj{42}-cms{41},
-    py{310,311,312}-dj{42,50,51}-cms{41}
+    py{310,311,312,313}-dj{42,50,51,52}-cms{41,50}
 
 skip_missing_interpreters=True
 
@@ -40,11 +40,13 @@ deps =
     dj42: Django>=4.2,<5.0
     dj50: Django>=5.0,<5.1
     dj51: Django>=5.1,<5.2
+    dj52: Django>=5.2,<5.3
     cms41: django-cms>=4.1,<4.2
+    cms50: django-cms>=5.0,<5.1
 
 commands =
     {envpython} --version
     {env:COMMAND:coverage} erase
-    {env:COMMAND:coverage} run setup.py test
+    {env:COMMAND:coverage} run tests/settings.py
     {env:COMMAND:coverage} report
 


### PR DESCRIPTION
## Changes

* Fix: Replaced get_plugin_tree_as_json (deprecated; removed in 5.1) with get_plugin_tree. get_plugin_tree_as_json seems to have stopped working correctly in 5.0, internally crashing with `KeyError: 0`. This replacement resolves that issue, grants (future) 5.1 compatibility regarding this code fragment and simplifies it a bit.

* Convenience: djangocms-transfer only exports JSON files; it therefore seems just necessary to me for better user convenience to just filter for *.json files.

* Restored callback invocation. Since control flow changed a bit when it was refactored for django-cms 4 compatibility, it was necessary to adjust the function signature. Purpose: Some systems based on django-cms and djangocms_transfer rely on being able to determine a fallback object, in case there is a related object being referenced, but could not be found (datastructures.py, l.56). See the updated README code example.

* Added django-cms 5.0 and the latest stable Python version (3.13) to test pipeline

* tox.ini: Replaced deprecated 'setup.py test' call

## Checklist

* [x] I have opened this pull request against ``master``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Enable django-cms 5.0 compatibility, refine export/import behavior, and restore user-defined import callbacks.

New Features:
- Add django-cms 5.0 support by replacing deprecated get_plugin_tree_as_json with get_plugin_tree
- Restore invocation of user-configured import callback for plugin data processing
- Restrict import form to accept only JSON files for improved user convenience

Enhancements:
- Update tox.ini to include Python 3.13 testing and replace deprecated setup.py test invocation
- Extend GitHub Actions matrix to cover django-cms 5.0 environments

Documentation:
- Update README with example for configuring import callbacks

Tests:
- Add requirements files for django-cms 5.0 testing environments