### PR TITLE
chore: Remove duplicate reference to process hook

### DIFF
--- a/djangocms_transfer/__init__.py
+++ b/djangocms_transfer/__init__.py
@@ -9,7 +9,7 @@ def get_serializer_name(default="python"):
     return getattr(settings, "DJANGO_CMS_TRANSFER_SERIALIZER", default)
 
 
-def custom_process_hook(transfer_hook, plugin, plugin_data=None):
+def custom_process_hook(transfer_hook, plugin, plugin_data):
     from importlib import import_module
 
     from django.conf import settings
@@ -24,7 +24,4 @@ def custom_process_hook(transfer_hook, plugin, plugin_data=None):
     except (ImportError, AttributeError) as e:
         raise ImportError(f"Could not import '{hook}': {e}")
 
-    if plugin_data:
-        return func(plugin, plugin_data)
-    else:
-        return func(plugin)
+    return func(plugin, plugin_data)

--- a/djangocms_transfer/datastructures.py
+++ b/djangocms_transfer/datastructures.py
@@ -1,10 +1,7 @@
-import importlib
 from collections import namedtuple
-from typing import Callable
 
 from cms.api import add_plugin
 from cms.models import CMSPlugin
-from django.conf import settings
 from django.core.serializers import deserialize
 from django.db import transaction
 from django.utils.encoding import force_str
@@ -68,7 +65,6 @@ class ArchivedPlugin(BaseArchivedPlugin):
             target=parent,
             **data,
         )
-        self._call_user_site_import_processor_if_necessary(plugin, self.data)
 
         field = ("target",) if plugin_target else ()
         # An empty *update_fields* iterable will skip the save
@@ -89,28 +85,6 @@ class ArchivedPlugin(BaseArchivedPlugin):
         # customize plugin-data on import with configured function
         custom_process_hook(
             "DJANGOCMS_TRANSFER_PROCESS_IMPORT_PLUGIN_DATA",
-            plugin
+            plugin, self.data
         )
-
-        plugin.save()
         return plugin
-
-    def _call_user_site_import_processor_if_necessary(
-        self, plugin: CMSPlugin, plugin_data: dict
-    ):
-        # customize plugin-data on import with configured function
-        if processor_symbol := getattr(
-            settings, "DJANGOCMS_TRANSFER_PROCESS_IMPORT_PLUGIN_DATA", None
-        ):
-            function = self._resolve_function_from_full_path(processor_symbol)
-            function(plugin, plugin_data)
-
-    def _resolve_function_from_full_path(
-        self, fully_qualified_path: str
-    ) -> Callable:
-        try:
-            module_name, function_name = fully_qualified_path.rsplit(".", 1)
-            module = importlib.import_module(module_name)
-            return getattr(module, function_name)
-        except (AttributeError, ImportError):
-            raise ImportError(f"could not resolve {fully_qualified_path}")

--- a/tests/transfer/test_helper.py
+++ b/tests/transfer/test_helper.py
@@ -27,7 +27,7 @@ class CustomProcessHookTest(FunctionalityBaseTestCase):
             ImportError,
             custom_process_hook,
             "DJANGOCMS_TRANSFER_PROCESS_IMPORT_PLUGIN_DATA",
-            self.plugin
+            self.plugin, self.plugin_data
         )
         self.assertRaises(
             ImportError,
@@ -41,9 +41,9 @@ class CustomProcessHookTest(FunctionalityBaseTestCase):
         self.assertTrue(
             custom_process_hook(
                 "DJANGOCMS_TRANSFER_PROCESS_IMPORT_PLUGIN_DATA",
-                self.plugin
+                self.plugin, {}
             ),
-            self.plugin
+            (self.plugin, {})
         )
         self.assertTrue(
             custom_process_hook(


### PR DESCRIPTION
## Description

[ca9c318736bfa5345a3e7](https://github.com/django-cms/djangocms-transfer/commit/ca9c318736bfa5345a3e7bfac04828c7c377faf7) introduces an import processor which
has already been defined. This PR removes the duplicate and extends the custom hook to work as described
in the docs.


<!--
If this is a security issue stop right here and follow our documentation:
http://docs.django-cms.org/en/latest/contributing/development-policies.html#reporting-security-issues
-->

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``master``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on 
[Discord](https://www.django-cms.org/discord) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Consolidate and simplify the plugin import processing by removing duplicate helper methods and always using the unified custom_process_hook interface with explicit plugin_data parameter, and update tests accordingly.

Enhancements:
- Remove duplicate import processor and obsolete helper methods from datastructures
- Require plugin_data in custom_process_hook signature and streamline hook invocation
- Update tests to pass plugin_data to custom_process_hook and reflect its simplified API

Tests:
- Adjust tests to supply plugin_data to custom_process_hook and validate its return signature