### PR TITLE
tests: Add extensive tests for ArchivedPlugin.restore

### DIFF
--- a/djangocms_transfer/cms_toolbars.py
+++ b/djangocms_transfer/cms_toolbars.py
@@ -14,8 +14,7 @@ class PluginImporter(CMSToolbar):
 
     def populate(self):
         # always use draft if we have a page
-        page = self.request.current_page
-
+        page = getattr(self.request, "current_page", None)
         if not page:
             return
 

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -18,6 +18,7 @@ INSTALLED_APPS = [
     "djangocms_text",
     "djangocms_link",
     "djangocms_transfer",
+    "tests.test_app",
 ]
 
 MIDDLEWARE = [

--- a/tests/test_app/cms_plugins.py
+++ b/tests/test_app/cms_plugins.py
@@ -1,0 +1,18 @@
+from cms.plugin_base import CMSPluginBase
+from cms.plugin_pool import plugin_pool
+
+from .models import Article, ArticlePluginModel
+
+
+class RandomPlugin(CMSPluginBase):
+    model = Article
+    render_plugin = False
+
+
+class ArticlePlugin(CMSPluginBase):
+    model = ArticlePluginModel
+    render_plugin = False
+
+
+plugin_pool.register_plugin(RandomPlugin)
+plugin_pool.register_plugin(ArticlePlugin)

--- a/tests/test_app/models.py
+++ b/tests/test_app/models.py
@@ -1,0 +1,25 @@
+from cms.models import CMSPlugin
+from django.db import models
+
+
+class Article(CMSPlugin):
+    title = models.CharField(max_length=50)
+    section = models.ForeignKey('Section', on_delete=models.CASCADE)
+
+    def __str__(self):
+        return f"{self.title} -- {self.section}"
+
+
+class Section(models.Model):
+    name = models.CharField(max_length=50)
+
+    def __str__(self):
+        return self.name
+
+
+class ArticlePluginModel(CMSPlugin):
+    title = models.CharField(max_length=50)
+    sections = models.ManyToManyField('Section')
+
+    def __str__(self):
+        return self.title

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,4 +1,5 @@
 import json
+import unittest
 
 from cms.models import CMSPlugin
 from djangocms_text.utils import plugin_to_tag
@@ -11,9 +12,54 @@ from djangocms_transfer.exporter import export_placeholder, export_plugin
 from djangocms_transfer.importer import import_plugins, import_plugins_to_page
 
 from .abstract import FunctionalityBaseTestCase
+from .test_app.models import Section
 
 
 class ImportTest(FunctionalityBaseTestCase):
+    def test_archivedplugin_restore_for_m2m_field(self):
+        plugin = self._create_plugin(plugin_type="ArticlePlugin", title="Test")
+        plugin.sections.set([
+            Section.objects.create(name="body"),
+            Section.objects.create(name="inner-body")
+        ])
+        archived_plugin = ArchivedPlugin(**json.loads(export_plugin(plugin))[0])
+
+        placeholder = self.page_content.placeholders.create(slot="test")
+        restored_plugin = archived_plugin.restore(placeholder, "en")
+        self.assertEqual(restored_plugin.title, "Test")
+        # second ArticlePluginModel instance in a new placeholder
+        self.assertEqual(restored_plugin.position, 1)
+        self.assertEqual(
+            restored_plugin.sections.get(name="body"),
+            plugin.sections.get(name="body")
+        )
+
+    def test_archivedplugin_restore_for_existing_related_field(self):
+        placeholder = self.page_content.placeholders.create(slot="test")
+        article_data = {"title": "Test",
+                        "section": Section.objects.create(name="body")}
+        plugin = self._create_plugin(plugin_type="RandomPlugin", **article_data)
+        plugin_data = json.loads(export_plugin(plugin))[0]
+        archived_plugin = ArchivedPlugin(**plugin_data)
+
+        restored_plugin = archived_plugin.restore(placeholder, "en")
+        self.assertEqual(restored_plugin.title, "Test")
+        self.assertEqual(restored_plugin.position, 1)
+        self.assertEqual(restored_plugin.section, plugin.section)
+
+    @unittest.skip("TODO: fix 'field.related_model.DoesNotExist' on ArchivedPlugin.restore")
+    def test_archivedplugin_restore_for_non_existing_related_field(self):
+        placeholder = self.page_content.placeholders.create(slot="test")
+        article_data = {"title": "Test",
+                        "section": Section.objects.create(name="body")}
+        plugin = self._create_plugin(plugin_type="RandomPlugin", **article_data)
+        plugin_data = json.loads(export_plugin(plugin))[0]
+        plugin_data["data"].pop("section") # remove section from the plugin's data
+        no_section_archived_plugin = ArchivedPlugin(**plugin_data)
+
+        no_section_restored_plugin = no_section_archived_plugin.restore(placeholder, "en")
+        self.assertEqual(no_section_restored_plugin.section, None)
+
     def test_import(self):
         pagecontent = self.page_content
         placeholder = pagecontent.get_placeholders().get(slot="content")

--- a/tests/test_toolbar.py
+++ b/tests/test_toolbar.py
@@ -1,0 +1,83 @@
+from cms.toolbar_pool import toolbar_pool
+
+from .abstract import FunctionalityBaseTestCase
+
+
+class PluginImporterToolbarTestCase(FunctionalityBaseTestCase):
+    def setUp(self):
+        super().setUp()
+        self.toolbars = toolbar_pool.get_toolbars()
+        self.plugin_toolbar = next(
+            (toolbar for toolbar in self.toolbars if toolbar.split(".")[-1] == "PluginImporter"),
+            None
+        )
+
+    def tearDown(self):
+        toolbar_pool.clear()
+        [toolbar_pool.register(toolbar) for _, toolbar in self.toolbars.items()]
+
+    def _only_plugin_importer_toolbar(self):
+        toolbar_pool.clear()
+        toolbar_pool.register(self.toolbars[self.plugin_toolbar])
+
+    def test_toolbar_populate_no_page(self):
+        self._only_plugin_importer_toolbar()
+        with self.login_user_context(self.get_staff_user_with_std_permissions()):
+            response = self.client.get("/en/admin/cms/pagecontent/")
+            self.assertEqual(response.status_code, 200)
+            page_menu = response.wsgi_request.toolbar.get_menu("page")
+            self.assertEqual(page_menu, None)
+
+    def test_toolbar_populate_user_cannot_change_page(self):
+        self._only_plugin_importer_toolbar()
+        with self.login_user_context(self.get_staff_user_with_no_permissions()):
+            response = self.client.get(self.get_pages_root())
+            self.assertEqual(response.status_code, 200)
+            page_menu = response.wsgi_request.toolbar.get_menu("page")
+            self.assertEqual(page_menu, None)
+
+    def test_toolbar_populate_page_menu_doesnot_exist(self):
+        self._only_plugin_importer_toolbar()
+        with self.login_user_context(self.get_staff_user_with_std_permissions()):
+            response = self.client.get(self.get_pages_root())
+            self.assertEqual(response.status_code, 200)
+            page_menu = response.wsgi_request.toolbar.get_menu("page")
+            self.assertEqual(page_menu, None)
+
+    def test_toolbar_populate_no_obj_in_toolbar(self):
+        self._only_plugin_importer_toolbar()
+        with self.login_user_context(self.get_staff_user_with_std_permissions()):
+            response = self.client.get(self.get_pages_root())
+            self.assertEqual(response.status_code, 200)
+            response.wsgi_request.toolbar.obj = None
+            page_menu = response.wsgi_request.toolbar.get_menu("page")
+            self.assertEqual(page_menu, None)
+
+    def test_toolbar_populate_no_pagecontent_obj(self):
+        with self.login_user_context(self.get_staff_user_with_std_permissions()):
+            response = self.client.get(self.get_pages_root())
+            self.assertEqual(response.status_code, 200)
+            response.wsgi_request.toolbar.obj = "not page content"
+            page_menu = response.wsgi_request.toolbar.get_menu("page")
+            self.assertFalse([
+                item for item in page_menu.items
+                if getattr(item, "identifier", "") == "Page menu importer break"
+            ])
+
+    def test_toolbar_populate_pagecontent_obj(self):
+        with self.login_user_context(self.get_staff_user_with_std_permissions()):
+            response = self.client.get(self.get_pages_root())
+            self.assertEqual(response.status_code, 200)
+            page_menu = response.wsgi_request.toolbar.get_menu("page")
+            self.assertTrue([
+                item for item in page_menu.items
+                if getattr(item, "identifier", "") == "Page menu importer break"
+            ])
+            self.assertTrue([
+                item for item in page_menu.items
+                if getattr(item, "name", "") == "Export"
+            ])
+            self.assertTrue([
+                item for item in page_menu.items
+                if getattr(item, "name", "").startswith("Import")
+            ])


### PR DESCRIPTION
## Description
- Update codebase to use helpers from django-cms
- Add more tests for ArchivedPlugin.restore

* [x] I have opened this pull request against ``master``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on 
[Discord](https://www.django-cms.org/discord) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Strengthen ArchivedPlugin restore behavior and align plugin model lookup with django CMS helpers.

Enhancements:
- Replace local plugin model resolution with django CMS's built-in get_plugin_model helper.

Tests:
- Add comprehensive tests for ArchivedPlugin.restore covering many-to-many and foreign key fields, including a skipped case documenting current failure behavior.
- Introduce a dedicated test app with Article and Section plugin models to support the new restore tests and register corresponding CMS plugins.
- Update test settings to include the new test application.