### PR TITLE
feat: Add plugin across django-cms instances

### DIFF
--- a/djangocms_transfer/cms_plugins.py
+++ b/djangocms_transfer/cms_plugins.py
@@ -45,13 +45,31 @@ class PluginImporter(CMSPluginBase):
         ]
         return urlpatterns
 
-    @staticmethod
-    def _get_extra_menu_items(query_params, request):
-        data = urlencode({
-            "language": get_language_from_request(request),
-            **query_params
-        })
+    def get_extra_global_plugin_menu_items(self, request, plugin):
+        # django-cms 3.4 compatibility
+        return self.get_extra_plugin_menu_items(request, plugin)
+
+    @classmethod
+    def get_extra_plugin_menu_items(cls, request, plugin):
+        if plugin.plugin_type == cls.__name__:
+            return
+
+        data = urlencode(
+            {
+                "language": get_language_from_request(request),
+                "plugin": plugin.pk,
+            }
+        )
         return [
+            PluginMenuItem(
+                _("Plugin->Clipboard"),
+                url="",
+                data={},
+                action="none",
+                attributes={
+                    "plugin": "copy",
+                },
+            ),
             PluginMenuItem(
                 _("Export plugins"),
                 admin_reverse("cms_export_plugins") + "?" + data,
@@ -73,17 +91,33 @@ class PluginImporter(CMSPluginBase):
         ]
 
     @classmethod
-    def get_extra_plugin_menu_items(cls, request, plugin):
-        if plugin.plugin_type == cls.__name__:
-            return
-
-        data = {"plugin": plugin.pk}
-        return cls._get_extra_menu_items(data, request)
-
-    @classmethod
     def get_extra_placeholder_menu_items(cls, request, placeholder):  # noqa
-        data = {"placeholder": placeholder.pk}
-        return cls._get_extra_menu_items(data, request)
+        data = urlencode(
+            {
+                "language": get_language_from_request(request),
+                "placeholder": placeholder.pk,
+            }
+        )
+        return [
+            PluginMenuItem(
+                _("Export plugins"),
+                admin_reverse("cms_export_plugins") + "?" + data,
+                data={},
+                action="none",
+                attributes={
+                    "icon": "export",
+                },
+            ),
+            PluginMenuItem(
+                _("Import plugins"),
+                admin_reverse("cms_import_plugins") + "?" + data,
+                data={},
+                action="modal",
+                attributes={
+                    "icon": "import",
+                },
+            ),
+        ]
 
     @classmethod
     def import_plugins_view(cls, request):

--- a/djangocms_transfer/cms_toolbars.py
+++ b/djangocms_transfer/cms_toolbars.py
@@ -11,6 +11,7 @@ from django.utils.translation import gettext
 class PluginImporter(CMSToolbar):
     class Media:
         css = {"all": ("djangocms_transfer/css/transfer.css",)}
+        js = ["djangocms_transfer/js/plugin_copy.js"]
 
     def populate(self):
         # always use draft if we have a page

--- a/djangocms_transfer/static/djangocms_transfer/js/plugin_copy.js
+++ b/djangocms_transfer/static/djangocms_transfer/js/plugin_copy.js
@@ -1,0 +1,71 @@
+function getPluginFromEventTarget(tgt) {
+    var pluginEl = CMS.$(tgt).closest('.cms-draggable');
+    if (!pluginEl.length) return;
+    
+    const pluginId = (function () {
+        const draggables = pluginEl.attr('class').split(/\s+/);
+        for (var i=0; i<draggables.length; i++){
+            var m = draggables[i].match(/^cms-draggable-(\d+)$/);
+            if (m) return parseInt(m[1], 10);
+        }
+        return null;
+    })();
+
+    if (!pluginId) return;
+    const plugin = CMS._instances.find(
+        plugin => plugin && plugin.options.plugin_id == pluginId
+    );
+    return plugin
+}
+
+CMS.$(window).on('load', function () {
+    CMS.$(document).find('.cms-submenu-item a[data-plugin="copy"]').on(
+        'click', function (e) {
+            e.preventDefault();
+            e.stopImmediatePropagation();
+	    
+	    CMS.Plugin._hideSettingsMenu();
+
+	    var data = getPluginFromEventTarget(this);
+	    const options = data.options;
+	    console.log("OPTIONS: ", options);
+	    var request = {
+                type: 'POST',
+                url: CMS.API.Helpers.updateUrlWithPath(options.urls.copy_plugin),
+                data: {
+		    source_placeholder_id: options.placeholder_id,
+		    source_plugin_id: options.plugin_id || '',
+		    source_language: CMS.config.request.language,
+		    target_plugin_id: options.parent || '',
+		    target_placeholder_id: options.target,
+		    csrfmiddlewaretoken: CMS.config.csrf,
+		    target_language: CMS.config.request.language,
+		},
+                success(response) {
+                    // CMS.API.Messages.open({
+                    //     message: CMS.config.lang.success
+                    // });
+		    console.log("RESPONSE: ", response);
+                    // if (copyingFromLanguage) {
+                    //     CMS.API.StructureBoard.invalidateState('PASTE', $.extend({}, data, response));
+                    // } else {
+                    //     CMS.API.StructureBoard.invalidateState('COPY', response);
+                    // }
+                    // CMS.API.locked = false;
+                    // hideLoader();
+                },
+                error(jqXHR) {
+                    CMS.API.locked = false;
+                    var msg = CMS.config.lang.error;
+
+                    // trigger error
+                    CMS.API.Messages.open({
+                        message: msg + jqXHR.responseText || jqXHR.status + ' ' + jqXHR.statusText,
+                        error: true
+                    });
+                }
+            };
+	    CMS.$.ajax(request);
+
+        });
+});


### PR DESCRIPTION
## Description

Closes #53  

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``master``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on 
[Discord](https://www.django-cms.org/discord) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Add support for copying plugins via the CMS toolbar and extend export/import menu integration for plugins and placeholders.

New Features:
- Expose a new plugin menu entry to copy a plugin via the frontend toolbar and trigger a server-side copy action.
- Provide a JavaScript helper to hook into django CMS plugin instances and perform AJAX-based plugin copying from the structure board.

Enhancements:
- Align extra plugin and placeholder menu items with language-aware URLs and maintain compatibility with django CMS 3.4 toolbar APIs.