### PR TITLE
chore: upgrade GitHub Actions versions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,19 +24,19 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
           queries: +security-and-quality
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v2
+        uses: github/codeql-action/autobuild@v4
         if: ${{ matrix.language == 'javascript' || matrix.language == 'python' }}
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: "pip"

--- a/.github/workflows/publish-to-live-pypi.yml
+++ b/.github/workflows/publish-to-live-pypi.yml
@@ -10,9 +10,9 @@ jobs:
     name: Build and publish Python 🐍 distributions 📦 to pypi
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python 3.12
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.12'
 

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -10,9 +10,9 @@ jobs:
     name: Build and publish Python 🐍 distributions 📦 to TestPyPI
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python 3.12
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.12'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,9 +36,9 @@ jobs:
           - requirements-file: dj52_cms50.txt
             python-version: 3.9
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -51,6 +51,6 @@ jobs:
       run: coverage run -m pytest
 
     - name: Upload Coverage to Codecov
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@v6
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: [ "3.10", "3.11", "3.12", "3.13"]
         requirements-file: [
           dj42_cms41.txt,
           dj50_cms41.txt,
@@ -22,19 +22,6 @@ jobs:
         os: [
           ubuntu-latest,
         ]
-        exclude:
-          - requirements-file: dj50_cms41.txt
-            python-version: 3.9
-          - requirements-file: dj51_cms41.txt
-            python-version: 3.9
-          - requirements-file: dj52_cms41.txt
-            python-version: 3.9
-          - requirements-file: dj50_cms50.txt
-            python-version: 3.9
-          - requirements-file: dj51_cms50.txt
-            python-version: 3.9
-          - requirements-file: dj52_cms50.txt
-            python-version: 3.9
     steps:
     - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}

--- a/djangocms_transfer/forms.py
+++ b/djangocms_transfer/forms.py
@@ -102,7 +102,7 @@ class PluginExportForm(ExportImportForm):
         placeholder = data["placeholder"]
 
         if cms_pagecontent:
-            return "{}.json".format(cms_pagecontent.page.get_slug(language=language))
+            return f"{cms_pagecontent.page.get_slug(language=language)}.json"
         elif placeholder and placeholder.page is not None:
             return "{}_{}.json".format(
                 placeholder.page.get_slug(language=language),

--- a/djangocms_transfer/utils.py
+++ b/djangocms_transfer/utils.py
@@ -4,7 +4,7 @@ from cms.models import CMSPlugin
 from cms.plugin_pool import plugin_pool
 
 
-@lru_cache()
+@lru_cache
 def get_local_fields(model):
     opts = model._meta.concrete_model._meta
     fields = opts.local_fields
@@ -15,19 +15,19 @@ def get_local_fields(model):
     ]
 
 
-@lru_cache()
+@lru_cache
 def get_related_fields(model):
     opts = model._meta.concrete_model._meta
     fields = opts.local_fields + list(opts.many_to_many)
     return [field.name for field in fields if field.is_relation]
 
 
-@lru_cache()
+@lru_cache
 def get_plugin_class(plugin_type):
     return plugin_pool.get_plugin(plugin_type)
 
 
-@lru_cache()
+@lru_cache
 def get_plugin_fields(plugin_type):
     klass = get_plugin_class(plugin_type)
     if klass.model is CMSPlugin:
@@ -37,6 +37,6 @@ def get_plugin_fields(plugin_type):
     return [field.name for field in fields]
 
 
-@lru_cache()
+@lru_cache
 def get_plugin_model(plugin_type):
     return get_plugin_class(plugin_type).model

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
 ]
 dynamic = [ "version" ]
 readme = "README.rst"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = {text = "BSD-3-Clause"}
 authors = [
     {name = "Divio AG", email = "info@divio.ch"},
@@ -25,7 +25,6 @@ classifiers = [
     "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",


### PR DESCRIPTION
## Summary
- upgrade outdated GitHub Actions versions listed in the repository audit
- align workflow action references with their current supported versions

## Testing
- not run (workflow-only change)

## Summary by Sourcery

Update CI workflows to use the latest supported versions of core GitHub Actions and security analysis tools.

CI:
- Bump actions/checkout, actions/setup-python, and CodeQL actions to their newer major versions across all workflows.
- Update Codecov upload action to the latest major version in the test workflow.